### PR TITLE
fix the encoding error and also make it getActiveDocument every heart…

### DIFF
--- a/FusionWakaTime.py
+++ b/FusionWakaTime.py
@@ -104,7 +104,7 @@ def Contents():
         start_time = time.time()
 
         
-        folder,design,designName,folderName = getActiveDocument()[:4]
+        folder,design,folderName,designName = getActiveDocument()[:4]
 
         app.log("FusionDocument type: " + str(design))
 
@@ -115,7 +115,7 @@ def Contents():
         def sendHeartBeat():
             timestamp = int(time.time())
             if time.time() - lastActive < inactive_threshold: 
-                    folder,design,designName,folderName = getActiveDocument()[:4]
+                    folder,design,folderName,designName = getActiveDocument()[:4]
                     CliCommand = [
                     WakaTimePath,
                     '--key', APIKEY,

--- a/FusionWakaTime.py
+++ b/FusionWakaTime.py
@@ -62,7 +62,7 @@ def run(context):
         Contents()  # or move all its contents here directly
     except Exception as e:
         app.log(f"Run failed: {str(e)}")
-
+with open(parsePath) as fh: app.log(fh.read())
 
 def Contents():
     app.log("part -1")

--- a/FusionWakaTime.py
+++ b/FusionWakaTime.py
@@ -41,7 +41,15 @@ def getActiveDocument():
                 folder = design
     except Exception as e:
         app.log(f"Could not get Active Document: {e}")
-    return [folder,design]
+    if not folder:
+        folderName = "Untitled"
+    else:
+        folderName = folder.name
+    if not design:
+        designName = "Untitled"
+    else:
+        designName = design.name
+    return [folder,design,folderName,designName]
 
 def update_activity():
     global lastActive
@@ -60,9 +68,16 @@ def Contents():
     app.log("part -1")
     try:
         app.log("part 1")
+        
         parse=configparser.ConfigParser()
         parsePath = os.path.join(os.environ['USERPROFILE'], '.wakatime.cfg')
-        parse.read(parsePath)
+        encodings = ['utf-8-sig', 'utf-8', 'utf-16', 'latin_1']
+        for encoding in encodings:
+            try:
+                with open(parsePath, encoding=encoding) as fh: parse.read_file(fh)
+                break
+            except:
+                continue
 
         if os.path.exists(parsePath):
             APIKEY = parse.get('settings','api_key')
@@ -88,24 +103,8 @@ def Contents():
         timeout = 30
         start_time = time.time()
 
-        folder = None
-        design = None
-
-
-        data = getActiveDocument()
-
-        folder = data[0]
-        design = data[1]
-
-        if not folder:
-            folderName = "Untitled"
-        else:
-            folderName = folder.name
-
-        if not design:
-            designName = "Untitled"
-        else:
-            designName = design.name
+        
+        folder,design,designName,folderName = getActiveDocument()[:4]
 
         app.log("FusionDocument type: " + str(design))
 
@@ -116,6 +115,7 @@ def Contents():
         def sendHeartBeat():
             timestamp = int(time.time())
             if time.time() - lastActive < inactive_threshold: 
+                    folder,design,designName,folderName = getActiveDocument()[:4]
                     CliCommand = [
                     WakaTimePath,
                     '--key', APIKEY,


### PR DESCRIPTION
i got the `Run failed: Wrong number or type of arguments for overloaded function 'Application_log'`  error and i found it errors at the line `parse.read(parsePath)`
turns out the file was in UTF 8 encoding w a byte order mark so i modified the plugin to cycle through common encodings if the default doesnt work
i also found that when i auto ran the plugin on startup it only sends heartbeats for untitiled because it only runs getActiveDocument once so i made that happen every heartbeat